### PR TITLE
shell.nix: add `pjgs.glibcLocales` to `buildInputs`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -52,6 +52,7 @@ in pkgs.mkShell {
         test = "$PWD/test";
       })
       pkgs.nodejs
+      pkgs.glibcLocales
       pkgs.postgresql
       local-postgres
     ];


### PR DESCRIPTION
solved an issue on my machine with `lpg`

see https://stackoverflow.com/a/68425342